### PR TITLE
Fix addHeader and addFooter returning undefined pointer

### DIFF
--- a/src/ofxDatGui.cpp
+++ b/src/ofxDatGui.cpp
@@ -156,9 +156,8 @@ ofxDatGuiHeader* ofxDatGui::addHeader(string label)
             items.insert(items.begin(), mGuiHeader);
         }
         layoutGui();
-	}	else {
-		return mGuiHeader;
 	}
+    return mGuiHeader;
 }
 
 ofxDatGuiFooter* ofxDatGui::addFooter()
@@ -168,9 +167,8 @@ ofxDatGuiFooter* ofxDatGui::addFooter()
         items.push_back(mGuiFooter);
         mGuiFooter->onInternalEvent(this, &ofxDatGui::onInternalEventCallback);
         layoutGui();
-	}	else {
-		return mGuiFooter;
 	}
+    return mGuiFooter;
 }
 
 ofxDatGuiLabel* ofxDatGui::addLabel(string label)


### PR DESCRIPTION
Found that the first time you add a header or footer to an ofxDatGui, the functions overflow and the returned pointers are undefined. Fixed by always returning the gui header or footer pointer.