### PR TITLE
fix double free

### DIFF
--- a/src/core/ofxDatGuiComponent.cpp
+++ b/src/core/ofxDatGuiComponent.cpp
@@ -51,7 +51,6 @@ ofxDatGuiComponent::ofxDatGuiComponent(string label, ofxDatGuiTemplate* tmplt)
 
 ofxDatGuiComponent::~ofxDatGuiComponent()
 {
-    delete mFont;
     cout << "ofxDatGuiComponent deleted" << endl;
 }
 


### PR DESCRIPTION
The template destructor owns the font pointer and correctly deallocates it in its own destructor, deallocating it here leads to segfault. Though in the long run it's better to replace all the pointer with shared_ptr, as already some smart pointers are used in the code.

This is a neat project!