### PR TITLE
Allow adding existing folders

### DIFF
--- a/src/ofxDatGui.cpp
+++ b/src/ofxDatGui.cpp
@@ -347,6 +347,12 @@ ofxDatGuiFolder* ofxDatGui::addFolder(string label, ofColor color)
     return folder;
 }
 
+ofxDatGuiFolder* ofxDatGui::addFolder(ofxDatGuiFolder* folder)
+{
+    attachItem(folder);
+    return folder;
+}
+
 void ofxDatGui::attachItem(ofxDatGuiComponent* item)
 {
     if (mGuiFooter != nullptr){

--- a/src/ofxDatGui.h
+++ b/src/ofxDatGui.h
@@ -71,6 +71,7 @@ class ofxDatGui : public ofxDatGuiInteractiveObject
         ofxDatGuiColorPicker* addColorPicker(string label, ofColor color = ofColor::black);
         ofxDatGuiMatrix* addMatrix(string label, int numButtons, bool showLabels = false);
         ofxDatGuiFolder* addFolder(string label, ofColor color = ofColor::white);
+        ofxDatGuiFolder* addFolder(ofxDatGuiFolder* folder);
     
         ofxDatGuiHeader* getHeader();
         ofxDatGuiFooter* getFooter();


### PR DESCRIPTION
Small change here, but maybe a useful one? I have different classes that create a folder containing their parameters, and implement a `ofxDatGuiFolder* getGuiFolder()`. From `ofApp`, which manages the gui, I call this and build a panel which has controls for all my different classes under collapsible folders. This is sort of a stop-gap fix until multiple panels snapping together exists (which is probably a more legit approach), but does the job for me and might be useful to others. :+1: ?