### PR TITLE
Use shared_ptr<ofImage> for theme icons

### DIFF
--- a/src/components/ofxDatGuiButton.h
+++ b/src/components/ofxDatGuiButton.h
@@ -106,8 +106,8 @@ class ofxDatGuiToggle : public ofxDatGuiButton {
         void setTheme(ofxDatGuiTheme* theme)
         {
             setComponentStyle(theme);
-            radioOn.load(theme->icon.radioOn);
-            radioOff.load(theme->icon.radioOff);
+            radioOn = theme->icon.radioOn;
+            radioOff = theme->icon.radioOff;
             mStyle.stripe.color = theme->stripe.toggle;
             setWidth(theme->layout.width, theme->layout.labelWidth);
         }
@@ -142,9 +142,9 @@ class ofxDatGuiToggle : public ofxDatGuiButton {
                 ofxDatGuiButton::draw();
                 ofSetColor(mIcon.color);
                 if (mEnabled == true){
-                    radioOn.draw(x+mIcon.x, y+mIcon.y, mIcon.size, mIcon.size);
+                    radioOn->draw(x+mIcon.x, y+mIcon.y, mIcon.size, mIcon.size);
                 }   else{
-                    radioOff.draw(x+mIcon.x, y+mIcon.y, mIcon.size, mIcon.size);
+                    radioOff->draw(x+mIcon.x, y+mIcon.y, mIcon.size, mIcon.size);
                 }
                 ofPopStyle();
             }
@@ -168,8 +168,8 @@ class ofxDatGuiToggle : public ofxDatGuiButton {
     
     private:
         bool mEnabled;
-        ofImage radioOn;
-        ofImage radioOff;
+        shared_ptr<ofImage> radioOn;
+        shared_ptr<ofImage> radioOff;
 
 };
 

--- a/src/components/ofxDatGuiColorPicker.h
+++ b/src/components/ofxDatGuiColorPicker.h
@@ -64,7 +64,7 @@ class ofxDatGuiColorPicker : public ofxDatGuiTextInput {
             ofxDatGuiTextInput::setTheme(theme);
             mStyle.stripe.color = theme->stripe.colorPicker;
             pickerRect = ofRectangle(0, 0, mInput.getWidth(), (mStyle.height + mStyle.padding) * 3);
-            rainbow.image.load(theme->icon.rainbow);
+            rainbow.image = theme->icon.rainbow;
             rainbow.rect = ofRectangle(0, 0, 20, pickerRect.height - (mStyle.padding * 2));
             gradientRect = ofRectangle(0, 0, pickerRect.width - rainbow.rect.width - (mStyle.padding * 3), rainbow.rect.height);
             pickerBorder = theme->color.colorPicker.border;
@@ -118,7 +118,7 @@ class ofxDatGuiColorPicker : public ofxDatGuiTextInput {
                     ofSetColor(pickerBorder);
                     ofDrawRectangle(pickerRect);
                     ofSetColor(ofColor::white);
-                    rainbow.image.draw(rainbow.rect);
+                    rainbow.image->draw(rainbow.rect);
                     vbo.draw( GL_TRIANGLE_FAN, 0, 6 );
                 }
             ofPopStyle();
@@ -131,7 +131,7 @@ class ofxDatGuiColorPicker : public ofxDatGuiTextInput {
                     ofSetColor(pickerBorder);
                     ofDrawRectangle(pickerRect);
                     ofSetColor(ofColor::white);
-                    rainbow.image.draw(rainbow.rect);
+                    rainbow.image->draw(rainbow.rect);
                     vbo.draw( GL_TRIANGLE_FAN, 0, 6 );
                 ofPopStyle();
             }
@@ -230,7 +230,7 @@ class ofxDatGuiColorPicker : public ofxDatGuiTextInput {
         ofColor gColor;
     
         struct {
-            ofImage image;
+            shared_ptr<ofImage> image;
             ofRectangle rect;
         } rainbow;
     

--- a/src/components/ofxDatGuiGroups.h
+++ b/src/components/ofxDatGuiGroups.h
@@ -75,7 +75,7 @@ class ofxDatGuiGroup : public ofxDatGuiButton {
                 ofPushStyle();
                 ofxDatGuiButton::draw();
                 ofSetColor(mIcon.color);
-                mImage.draw(x+mIcon.x, y+mIcon.y, mIcon.size, mIcon.size);
+                mImage->draw(x+mIcon.x, y+mIcon.y, mIcon.size, mIcon.size);
                 if (mIsExpanded) {
                     int mHeight = mStyle.height;
                     ofSetColor(mStyle.guiBackground, mStyle.opacity);
@@ -133,7 +133,7 @@ class ofxDatGuiGroup : public ofxDatGuiButton {
         }
     
         int mHeight;
-        ofImage mImage;
+        shared_ptr<ofImage> mImage;
         bool mIsExpanded;
     
 };
@@ -153,7 +153,7 @@ class ofxDatGuiFolder : public ofxDatGuiGroup {
         void setTheme(ofxDatGuiTheme* theme)
         {
             setComponentStyle(theme);
-            mImage.load(theme->icon.dropdown);
+            mImage = theme->icon.dropdown;
             setWidth(theme->layout.width, theme->layout.labelWidth);
         // reassign folder color to all components //
             for(auto i:children) i->setStripeColor(mStyle.stripe.color);
@@ -410,7 +410,7 @@ class ofxDatGuiDropdown : public ofxDatGuiGroup {
         void setTheme(ofxDatGuiTheme* theme)
         {
             setComponentStyle(theme);
-            mImage.load(theme->icon.dropdown);
+            mImage = theme->icon.dropdown;
             mStyle.stripe.color = theme->stripe.dropdown;
             setWidth(theme->layout.width, theme->layout.labelWidth);
         }

--- a/src/themes/ofxDatGuiTheme.h
+++ b/src/themes/ofxDatGuiTheme.h
@@ -66,6 +66,18 @@ class ofxDatGuiTheme{
                 layout.textInput.highlightPadding *= 2;
             }
             font.ptr = ofxSmartFont::add(font.file, font.size);
+
+            icon.radioOn = make_shared<ofImage>();
+            icon.radioOn->load(icon.radioOnPath);
+
+            icon.radioOff = make_shared<ofImage>();
+            icon.radioOff->load(icon.radioOffPath);
+
+            icon.dropdown = make_shared<ofImage>();
+            icon.dropdown->load(icon.dropdownPath);
+
+            icon.rainbow = make_shared<ofImage>();
+            icon.rainbow->load(icon.rainbowPath);
         }
     
     /*
@@ -212,10 +224,15 @@ class ofxDatGuiTheme{
         } font;
     
         struct{
-            string rainbow = "ofxbraitsch/ofxdatgui/picker-rainbow.png";
-            string radioOn = "ofxbraitsch/ofxdatgui/icon-radio-on.png";
-            string radioOff = "ofxbraitsch/ofxdatgui/icon-radio-off.png";
-            string dropdown = "ofxbraitsch/ofxdatgui/icon-dropdown.png";
+            shared_ptr<ofImage> rainbow;
+            shared_ptr<ofImage> radioOn;
+            shared_ptr<ofImage> radioOff;
+            shared_ptr<ofImage> dropdown;
+
+            string rainbowPath = "ofxbraitsch/ofxdatgui/picker-rainbow.png";
+            string radioOnPath = "ofxbraitsch/ofxdatgui/icon-radio-on.png";
+            string radioOffPath = "ofxbraitsch/ofxdatgui/icon-radio-off.png";
+            string dropdownPath = "ofxbraitsch/ofxdatgui/icon-dropdown.png";
         } icon;
 
         static ofColor hex(int n)


### PR DESCRIPTION
Got tired of seeing tons of duplicate textures in the OpenGL profiler and figured they could get shared across components. Not sure if this implementation is the best route, but it seems to work?