### PR TITLE
Adding getLabel() methods to ofxDatGui objects of type Label

### DIFF
--- a/src/components/ofxDatGuiLabel.h
+++ b/src/components/ofxDatGuiLabel.h
@@ -66,6 +66,7 @@ class ofxDatGuiLabel : public ofxDatGuiComponent{
         
         ofxDatGuiLabel(string label) : ofxDatGuiComponent(label)
         {
+            mType = ofxDatGuiType::LABEL;
             setTheme(ofxDatGuiComponent::theme.get());
         }
     
@@ -87,5 +88,8 @@ class ofxDatGuiLabel : public ofxDatGuiComponent{
         {
             ofxDatGuiComponent::draw();
         }
+    
+        static ofxDatGuiLabel* getInstance() { return new ofxDatGuiLabel("X"); }
+
 
 };

--- a/src/ofxDatGui.cpp
+++ b/src/ofxDatGui.cpp
@@ -422,6 +422,22 @@ void ofxDatGui::attachItem(ofxDatGuiComponent* item)
     component retrieval methods
 */
 
+ofxDatGuiLabel* ofxDatGui::getLabel(string bl, string fl){
+    ofxDatGuiLabel* o = nullptr;
+    if (fl != ""){
+        ofxDatGuiFolder* f = static_cast<ofxDatGuiFolder*>(getComponent(ofxDatGuiType::FOLDER, fl));
+        if (f) o = static_cast<ofxDatGuiLabel*>(f->getComponent(ofxDatGuiType::LABEL, bl));
+    } else {
+        o = static_cast<ofxDatGuiLabel*>(getComponent(ofxDatGuiType::LABEL, bl));
+    }
+    if (o==nullptr){
+        o = ofxDatGuiLabel::getInstance();
+        ofxDatGuiLog::write(ofxDatGuiMsg::COMPONENT_NOT_FOUND, fl!="" ? fl+"-"+bl : bl);
+        trash.push_back(o);
+    }
+    return o;
+}
+
 ofxDatGuiButton* ofxDatGui::getButton(string bl, string fl)
 {
     ofxDatGuiButton* o = nullptr;

--- a/src/ofxDatGui.h
+++ b/src/ofxDatGui.h
@@ -83,6 +83,7 @@ class ofxDatGui : public ofxDatGuiInteractiveObject
     
         ofxDatGuiHeader* getHeader();
         ofxDatGuiFooter* getFooter();
+        ofxDatGuiLabel* getLabel(string label, string folder = "");
         ofxDatGuiButton* getButton(string label, string folder = "");
         ofxDatGuiToggle* getToggle(string label, string folder = "");
         ofxDatGuiSlider* getSlider(string label, string folder = "");


### PR DESCRIPTION
This fork allows for 'label' type objects attached to ofxDatGui objects to be called via a getLabel method, much like the standalone class. For example, you can now do something like:

In setup():
`gui = new ofxDatGui;`
`gui->addLabel("myLabel");`

In update():
`gui->getLabel("myLabel")->setLabel("Update Text in Label");`

Useful for things like updating the status of a variable or condition in your code.