### PR TITLE
colorPicker hex output fix!

### DIFF
--- a/src/components/ofxDatGuiColorPicker.h
+++ b/src/components/ofxDatGuiColorPicker.h
@@ -215,11 +215,8 @@ class ofxDatGuiColorPicker : public ofxDatGuiTextInput {
         inline void setTextFieldInputColor()
         {
         // convert color value to a six character hex string //
-            std::stringstream ss;
-            ss<< std::hex << mColor.getHex();
-            std::string res ( ss.str() );
-            while(res.size() < 6) res+="0";
-            mInput.setText(ofToUpper(res));
+			string hex = ofToHex(mColor.getHex()).substr(2);
+			mInput.setText(ofToUpper(hex));
             mInput.setBackgroundColor(mColor);
             mInput.setTextInactiveColor(mColor.getBrightness() < BRIGHTNESS_THRESHOLD ? ofColor::white : ofColor::black);
         }


### PR DESCRIPTION
The hex output was wrong. The trailing zeros were always appended even if a prepend were needed. I fixed the textfield output with ofToHex.

Best
Kim